### PR TITLE
Updated to Discord.Net 1.0.0-rc, Enabled Logging

### DIFF
--- a/DiscordExampleBot.sln
+++ b/DiscordExampleBot.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+VisualStudioVersion = 15.0.26228.12
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = "DiscordExampleBot", "DiscordExampleBot\DiscordExampleBot.csproj", "{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}"
 EndProject
@@ -14,21 +13,21 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Debug|x64.ActiveCfg = Debug|x64
-		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Debug|x64.Build.0 = Debug|x64
-		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Debug|x86.ActiveCfg = Debug|x86
-		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Debug|x86.Build.0 = Debug|x86
+		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Debug|x64.Build.0 = Debug|Any CPU
+		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Debug|x86.Build.0 = Debug|Any CPU
 		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Release|x64.ActiveCfg = Release|x64
-		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Release|x64.Build.0 = Release|x64
-		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Release|x86.ActiveCfg = Release|x86
-		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Release|x86.Build.0 = Release|x86
+		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Release|x64.ActiveCfg = Release|Any CPU
+		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Release|x64.Build.0 = Release|Any CPU
+		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Release|x86.ActiveCfg = Release|Any CPU
+		{29B973A9-ABD1-4A00-81F8-4A59589BBDE2}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/DiscordExampleBot/CommandHandler.cs
+++ b/DiscordExampleBot/CommandHandler.cs
@@ -16,7 +16,6 @@ namespace DiscordExampleBot
             // Create Command Service, inject it into Dependency Map
             client = _map.Get<DiscordSocketClient>();
             commands = new CommandService();
-            _map.Add(commands);
             map = _map;
 
             await commands.AddModulesAsync(Assembly.GetEntryAssembly());

--- a/DiscordExampleBot/CommandHandler.cs
+++ b/DiscordExampleBot/CommandHandler.cs
@@ -16,6 +16,8 @@ namespace DiscordExampleBot
             // Create Command Service, inject it into Dependency Map
             client = _map.Get<DiscordSocketClient>();
             commands = new CommandService();
+            commands.Log += Program.Log;
+
             map = _map;
 
             await commands.AddModulesAsync(Assembly.GetEntryAssembly());

--- a/DiscordExampleBot/DiscordExampleBot.csproj
+++ b/DiscordExampleBot/DiscordExampleBot.csproj
@@ -1,13 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Commands" Version="1.0.0-rc-00610" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="1.0.0-rc-00610" />
+    <PackageReference Include="Discord.Net.Commands" Version="1.0.0-rc-00652" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="1.0.0-rc-00652" />
   </ItemGroup>
-
 </Project>

--- a/DiscordExampleBot/DiscordExampleBot.csproj
+++ b/DiscordExampleBot/DiscordExampleBot.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Commands" Version="1.0.0-rc2-00673" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="1.0.0-rc2-00673" />
+    <PackageReference Include="Discord.Net.Commands" Version="1.0.0-rc" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="1.0.0-rc" />
   </ItemGroup>
 </Project>

--- a/DiscordExampleBot/DiscordExampleBot.csproj
+++ b/DiscordExampleBot/DiscordExampleBot.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Commands" Version="1.0.0-rc-00652" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="1.0.0-rc-00652" />
+    <PackageReference Include="Discord.Net.Commands" Version="1.0.0-rc2-00673" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="1.0.0-rc2-00673" />
   </ItemGroup>
 </Project>

--- a/DiscordExampleBot/Modules/Public/PublicModule.cs
+++ b/DiscordExampleBot/Modules/Public/PublicModule.cs
@@ -15,6 +15,7 @@ namespace DiscordExampleBot.Modules.Public
         [Summary("Returns the OAuth2 Invite URL of the bot")]
         public async Task Invite()
         {
+            Program.Log(new LogMessage(LogSeverity.Info, "PublicModule", "Invite"));
             var application = await Context.Client.GetApplicationInfoAsync();
             await ReplyAsync(
                 $"A user with `MANAGE_SERVER` can invite me to your server here: <https://discordapp.com/oauth2/authorize?client_id={application.Id}&scope=bot>");
@@ -25,7 +26,13 @@ namespace DiscordExampleBot.Modules.Public
         [RequireUserPermission(GuildPermission.ManageGuild)]
         public async Task Leave()
         {
-            if (Context.Guild == null) { await ReplyAsync("This command can only be ran in a server."); return; }
+            Program.Log(new LogMessage(LogSeverity.Info, "PublicModule", "Leave"));
+            if (Context.Guild == null)
+            {
+                await ReplyAsync("This command can only be ran in a server.");
+                Program.Log(new LogMessage(LogSeverity.Warning, "PublicModule.Leave", "This command can only be run in a server."));
+                return;
+            }
             await ReplyAsync("Leaving~");
             await Context.Guild.LeaveAsync();
         }
@@ -35,12 +42,14 @@ namespace DiscordExampleBot.Modules.Public
         [Summary("Echos the provided input")]
         public async Task Say([Remainder] string input)
         {
+            Program.Log(new LogMessage(LogSeverity.Info, "PublicModule", "Say/Echo : " + input));
             await ReplyAsync(input);
         }
 
         [Command("info")]
         public async Task Info()
         {
+            Program.Log(new LogMessage(LogSeverity.Info, "PublicModule", "Info"));
             var application = await Context.Client.GetApplicationInfoAsync();
             await ReplyAsync(
                 $"{Format.Bold("Info")}\n" +

--- a/DiscordExampleBot/Modules/Public/PublicModule.cs
+++ b/DiscordExampleBot/Modules/Public/PublicModule.cs
@@ -22,14 +22,9 @@ namespace DiscordExampleBot.Modules.Public
 
         [Command("leave")]
         [Summary("Instructs the bot to leave this Guild.")]
-        [RequireUserPermission(GuildPermission.ManageGuild)]
+        [RequireUserPermission(GuildPermission.ManageGuild), RequireContext(ContextType.Guild)]
         public async Task Leave()
         {
-            if (Context.Guild == null)
-            {
-                await ReplyAsync("This command can only be ran in a server.");
-                return;
-            }
             await ReplyAsync("Leaving~");
             await Context.Guild.LeaveAsync();
         }

--- a/DiscordExampleBot/Modules/Public/PublicModule.cs
+++ b/DiscordExampleBot/Modules/Public/PublicModule.cs
@@ -15,7 +15,6 @@ namespace DiscordExampleBot.Modules.Public
         [Summary("Returns the OAuth2 Invite URL of the bot")]
         public async Task Invite()
         {
-            Program.Log(new LogMessage(LogSeverity.Info, "PublicModule", "Invite"));
             var application = await Context.Client.GetApplicationInfoAsync();
             await ReplyAsync(
                 $"A user with `MANAGE_SERVER` can invite me to your server here: <https://discordapp.com/oauth2/authorize?client_id={application.Id}&scope=bot>");
@@ -26,11 +25,9 @@ namespace DiscordExampleBot.Modules.Public
         [RequireUserPermission(GuildPermission.ManageGuild)]
         public async Task Leave()
         {
-            Program.Log(new LogMessage(LogSeverity.Info, "PublicModule", "Leave"));
             if (Context.Guild == null)
             {
                 await ReplyAsync("This command can only be ran in a server.");
-                Program.Log(new LogMessage(LogSeverity.Warning, "PublicModule.Leave", "This command can only be run in a server."));
                 return;
             }
             await ReplyAsync("Leaving~");
@@ -42,14 +39,12 @@ namespace DiscordExampleBot.Modules.Public
         [Summary("Echos the provided input")]
         public async Task Say([Remainder] string input)
         {
-            Program.Log(new LogMessage(LogSeverity.Info, "PublicModule", "Say/Echo : " + input));
             await ReplyAsync(input);
         }
 
         [Command("info")]
         public async Task Info()
         {
-            Program.Log(new LogMessage(LogSeverity.Info, "PublicModule", "Info"));
             var application = await Context.Client.GetApplicationInfoAsync();
             await ReplyAsync(
                 $"{Format.Bold("Info")}\n" +

--- a/DiscordExampleBot/Program.cs
+++ b/DiscordExampleBot/Program.cs
@@ -17,8 +17,11 @@ namespace DiscordExampleBot
 
         public async Task Start()
         {
+            // make a configuration
+            DiscordSocketConfig clientConfig = new DiscordSocketConfig() { LogLevel = LogSeverity.Info };
+
             // Define the DiscordSocketClient
-            client = new DiscordSocketClient();
+            client = new DiscordSocketClient(clientConfig);
 
             var token = "token here";
 
@@ -31,6 +34,9 @@ namespace DiscordExampleBot
 
             handler = new CommandHandler();
             await handler.Install(map);
+
+            // add logger
+            client.Log += Log;
 
             // Block this program until it is closed.
             await Task.Delay(-1);

--- a/DiscordExampleBot/Program.cs
+++ b/DiscordExampleBot/Program.cs
@@ -40,7 +40,8 @@ namespace DiscordExampleBot
             await Task.Delay(-1);
         }
 
-        private Task Log(LogMessage msg)
+        // Bare minimum Logging function for both DiscordSocketClient and commands
+        public static Task Log(LogMessage msg)
         {
             Console.WriteLine(msg.ToString());
             return Task.CompletedTask;

--- a/DiscordExampleBot/Program.cs
+++ b/DiscordExampleBot/Program.cs
@@ -40,7 +40,7 @@ namespace DiscordExampleBot
             await Task.Delay(-1);
         }
 
-        // Bare minimum Logging function for both DiscordSocketClient and commands
+        // Bare minimum Logging function for both DiscordSocketClient and CommandService
         public static Task Log(LogMessage msg)
         {
             Console.WriteLine(msg.ToString());

--- a/DiscordExampleBot/Program.cs
+++ b/DiscordExampleBot/Program.cs
@@ -17,11 +17,9 @@ namespace DiscordExampleBot
 
         public async Task Start()
         {
-            // make a configuration
-            DiscordSocketConfig clientConfig = new DiscordSocketConfig() { LogLevel = LogSeverity.Info };
-
-            // Define the DiscordSocketClient
-            client = new DiscordSocketClient(clientConfig);
+            
+            // Define the DiscordSocketClient with a DiscordSocketConfig
+            client = new DiscordSocketClient(new DiscordSocketConfig() { LogLevel = LogSeverity.Info });
 
             var token = "token here";
 

--- a/DiscordExampleBot/Program.cs
+++ b/DiscordExampleBot/Program.cs
@@ -36,8 +36,19 @@ namespace DiscordExampleBot
             // add logger
             client.Log += Log;
 
+            // Log the invite URL on client ready
+            client.Ready += Client_Ready;
+
             // Block this program until it is closed.
             await Task.Delay(-1);
+        }
+
+        // log the OAuth2 Invite URL of the bot on client ready so that user can see it on startup
+        private async Task Client_Ready()
+        {
+            var application = await client.GetApplicationInfoAsync();
+            await Log(new LogMessage(LogSeverity.Info, "Program",
+                $"Invite URL: <https://discordapp.com/oauth2/authorize?client_id={application.Id}&scope=bot>"));
         }
 
         // Bare minimum Logging function for both DiscordSocketClient and CommandService


### PR DESCRIPTION
Updated to Discord.Net 1.0.0-rc-00625. All commands work.

Added a DiscordSocketConfig in Bot.Start() that specified LogLevel. Added Log handler to client.

Had to remove the line `_map.Add(commands);` in CommandHandler.cs that would throw an InvalidOperationException in version 1.0.0-rc-00652. "The dependency map already contains Discord.Commands.CommandService".

EDIT: The discord group informs me that CommandServices can no longer be added to dependency map.